### PR TITLE
Update badass.py to allow user specified voff init and plim

### DIFF
--- a/badass.py
+++ b/badass.py
@@ -4284,7 +4284,13 @@ def initialize_line_pars(lam_gal,galaxy,noise,comp_options,
 
         # Velocity offsets determine both the intial guess in line velocity as well as amplitude, so it makes sense to perform the voff for each line first.
         if (("voff" in line_list[line]) and (line_list[line]["voff"]=="free")):
-            voff_default = voff_hyperpars(line_list[line]["line_type"],line_list[line]["center"])
+           if "voff_init" in line_list[line] and "voff_plim" in line_list[line]:
+               # If user has provided an initial guess, use that
+               voff_default = (line_list[line]["voff_init"],line_list[line]["voff_plim"])
+           else:
+               # If user has not provided an initial guess, use the hyperparameters
+               voff_default = voff_hyperpars(line_list[line]["line_type"],line_list[line]["center"])
+
             line_par_input[line+"_VOFF"] = {"init": line_list[line].get("voff_init",voff_default[0]), 
                                             "plim":line_list[line].get("voff_plim",voff_default[1]),
                                             "prior":line_list[line].get("voff_prior",{"type":"gaussian"})


### PR DESCRIPTION
Previously badass would only automatically set voff init and plim. Now users can specify the init and plim in their user_lines. e.g. "NA_OIII_5007"   :{"center":5008.240,"amp":"free","disp":"free","voff":"free","voff_init":0,"voff_plim":(-500,500),"line_type":"na","label":r"[O III]","ncomp":1,}